### PR TITLE
remove redundant license and /old, add paper

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -1,15 +1,17 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-<meta charset="utf-8">
-<meta http-equiv="X-UA-Compatible" content="IE=edge">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-{% seo -%}
-<meta name="author" content="Anurag Priyam">
-<meta name="author" content="Yannick Wurm">
-<meta name="keywords" content="local NCBI BLAST, custom BLAST, local BLAST server, BLAST web frontend, local BLAST, BLAST web interface, galaxy, viroblast">
-    <!-- Support HTML5 elements and media queries on IE8 and less. -->
-    <!--[if lt IE 9]>
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  {% seo -%}
+  <meta name="author" content="Anurag Priyam">
+  <meta name="author" content="Yannick Wurm">
+  <meta name="keywords"
+    content="local NCBI BLAST, custom BLAST, local BLAST server, BLAST web frontend, local BLAST, BLAST web interface, galaxy, viroblast">
+  <!-- Support HTML5 elements and media queries on IE8 and less. -->
+  <!--[if lt IE 9]>
       <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.2/html5shiv.min.js"></script>
     <![endif]-->
 
@@ -34,6 +36,7 @@
     ga('send', 'pageview');
   </script>
 </head>
+
 <body>
   <nav class="navbar navbar-expand-xl navbar-light fixed-top">
     <div class="container">
@@ -81,8 +84,8 @@
             </a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="/#license">
-              License
+            <a class="nav-link" href="/paper">
+              Paper
             </a>
           </li>
           <li class="nav-item">
@@ -104,7 +107,7 @@
     </div>
   </nav>
   <div class="container">
-{% include stats-banner.html %}
+    {% include stats-banner.html %}
     {{ content }}
   </div>
 
@@ -123,10 +126,6 @@
         Parts of SequenceServer are &copy; Universit&eacute; de Lausanne
         (2011).
       </p>
-      <p>
-        Archived site: <a href="http://www.sequenceserver.com/old/">
-          SequenceServer 0.8 (pre March 2015)</a>.
-      </p>
     </div>
   </footer>
 
@@ -136,14 +135,14 @@
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"
     integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM"
     crossorigin="anonymous"></script>
-    <script>
-      $(function(){
-        var navMain = $(".navbar-collapse");
-        navMain.on("click", "a:not([data-toggle])", null, function () {
-            navMain.collapse('hide');
-        });
+  <script>
+    $(function () {
+      var navMain = $(".navbar-collapse");
+      navMain.on("click", "a:not([data-toggle])", null, function () {
+        navMain.collapse('hide');
+      });
     });
-    </script>
+  </script>
 </body>
 
 </html>

--- a/_site/blog/sequence-search/index.html
+++ b/_site/blog/sequence-search/index.html
@@ -1,10 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-<meta charset="utf-8">
-<meta http-equiv="X-UA-Compatible" content="IE=edge">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<!-- Begin Jekyll SEO tag v2.7.1 -->
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!-- Begin Jekyll SEO tag v2.7.1 -->
 <title>Sequence Search | SequenceServer</title>
 <meta name="generator" content="Jekyll v3.9.1" />
 <meta property="og:title" content="Sequence Search" />
@@ -22,10 +23,11 @@
 {"@type":"BlogPosting","description":"Sequence Search","headline":"Sequence Search","dateModified":"2021-07-24T23:03:32-07:00","datePublished":"2021-07-24T23:03:32-07:00","mainEntityOfPage":{"@type":"WebPage","@id":"http://localhost:4000/blog/sequence-search/"},"url":"http://localhost:4000/blog/sequence-search/","@context":"https://schema.org"}</script>
 <!-- End Jekyll SEO tag -->
 <meta name="author" content="Anurag Priyam">
-<meta name="author" content="Yannick Wurm">
-<meta name="keywords" content="local NCBI BLAST, custom BLAST, local BLAST server, BLAST web frontend, local BLAST, BLAST web interface, galaxy, viroblast">
-    <!-- Support HTML5 elements and media queries on IE8 and less. -->
-    <!--[if lt IE 9]>
+  <meta name="author" content="Yannick Wurm">
+  <meta name="keywords"
+    content="local NCBI BLAST, custom BLAST, local BLAST server, BLAST web frontend, local BLAST, BLAST web interface, galaxy, viroblast">
+  <!-- Support HTML5 elements and media queries on IE8 and less. -->
+  <!--[if lt IE 9]>
       <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.2/html5shiv.min.js"></script>
     <![endif]-->
 
@@ -50,6 +52,7 @@
     ga('send', 'pageview');
   </script>
 </head>
+
 <body>
   <nav class="navbar navbar-expand-xl navbar-light fixed-top">
     <div class="container">
@@ -97,8 +100,8 @@
             </a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="/#license">
-              License
+            <a class="nav-link" href="/paper">
+              Paper
             </a>
           </li>
           <li class="nav-item">
@@ -120,7 +123,7 @@
     </div>
   </nav>
   <div class="container">
-<div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 g-4 py-5 stats-banner" role="banner">
+    <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 g-4 py-5 stats-banner" role="banner">
     <div class="">
         <div>
             <p><i class="fa fa-quote-left" aria-hidden="true"></i> 130+ citations</p>
@@ -212,10 +215,6 @@ In this bird’s-eye review, we overview the evolution of main algorithmic techn
         Parts of SequenceServer are &copy; Universit&eacute; de Lausanne
         (2011).
       </p>
-      <p>
-        Archived site: <a href="http://www.sequenceserver.com/old/">
-          SequenceServer 0.8 (pre March 2015)</a>.
-      </p>
     </div>
   </footer>
 
@@ -225,14 +224,14 @@ In this bird’s-eye review, we overview the evolution of main algorithmic techn
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"
     integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM"
     crossorigin="anonymous"></script>
-    <script>
-      $(function(){
-        var navMain = $(".navbar-collapse");
-        navMain.on("click", "a:not([data-toggle])", null, function () {
-            navMain.collapse('hide');
-        });
+  <script>
+    $(function () {
+      var navMain = $(".navbar-collapse");
+      navMain.on("click", "a:not([data-toggle])", null, function () {
+        navMain.collapse('hide');
+      });
     });
-    </script>
+  </script>
 </body>
 
 </html>

--- a/_site/doc/index.html
+++ b/_site/doc/index.html
@@ -1,10 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-<meta charset="utf-8">
-<meta http-equiv="X-UA-Compatible" content="IE=edge">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<!-- Begin Jekyll SEO tag v2.7.1 -->
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!-- Begin Jekyll SEO tag v2.7.1 -->
 <title>SequenceServer | Use SequenceServer to pragmatically perform and interpret genomic comparisons using NCBI BLAST. SequenceServer accelerates your analyses so you can focus on the science.</title>
 <meta name="generator" content="Jekyll v3.9.1" />
 <meta property="og:title" content="SequenceServer" />
@@ -20,10 +21,11 @@
 {"@type":"WebPage","description":"Use SequenceServer to pragmatically perform and interpret genomic comparisons using NCBI BLAST. SequenceServer accelerates your analyses so you can focus on the science.","headline":"SequenceServer","url":"http://localhost:4000/doc/","@context":"https://schema.org"}</script>
 <!-- End Jekyll SEO tag -->
 <meta name="author" content="Anurag Priyam">
-<meta name="author" content="Yannick Wurm">
-<meta name="keywords" content="local NCBI BLAST, custom BLAST, local BLAST server, BLAST web frontend, local BLAST, BLAST web interface, galaxy, viroblast">
-    <!-- Support HTML5 elements and media queries on IE8 and less. -->
-    <!--[if lt IE 9]>
+  <meta name="author" content="Yannick Wurm">
+  <meta name="keywords"
+    content="local NCBI BLAST, custom BLAST, local BLAST server, BLAST web frontend, local BLAST, BLAST web interface, galaxy, viroblast">
+  <!-- Support HTML5 elements and media queries on IE8 and less. -->
+  <!--[if lt IE 9]>
       <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.2/html5shiv.min.js"></script>
     <![endif]-->
 
@@ -48,6 +50,7 @@
     ga('send', 'pageview');
   </script>
 </head>
+
 <body>
   <nav class="navbar navbar-expand-xl navbar-light fixed-top">
     <div class="container">
@@ -95,8 +98,8 @@
             </a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="/#license">
-              License
+            <a class="nav-link" href="/paper">
+              Paper
             </a>
           </li>
           <li class="nav-item">
@@ -118,7 +121,7 @@
     </div>
   </nav>
   <div class="container">
-<div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 g-4 py-5 stats-banner" role="banner">
+    <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 g-4 py-5 stats-banner" role="banner">
     <div class="">
         <div>
             <p><i class="fa fa-quote-left" aria-hidden="true"></i> 130+ citations</p>
@@ -1204,10 +1207,6 @@ qsub <span class="nt">-sync</span> y <span class="nt">-b</span> y <span class="n
         Parts of SequenceServer are &copy; Universit&eacute; de Lausanne
         (2011).
       </p>
-      <p>
-        Archived site: <a href="http://www.sequenceserver.com/old/">
-          SequenceServer 0.8 (pre March 2015)</a>.
-      </p>
     </div>
   </footer>
 
@@ -1217,14 +1216,14 @@ qsub <span class="nt">-sync</span> y <span class="nt">-b</span> y <span class="n
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"
     integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM"
     crossorigin="anonymous"></script>
-    <script>
-      $(function(){
-        var navMain = $(".navbar-collapse");
-        navMain.on("click", "a:not([data-toggle])", null, function () {
-            navMain.collapse('hide');
-        });
+  <script>
+    $(function () {
+      var navMain = $(".navbar-collapse");
+      navMain.on("click", "a:not([data-toggle])", null, function () {
+        navMain.collapse('hide');
+      });
     });
-    </script>
+  </script>
 </body>
 
 </html>

--- a/_site/index.html
+++ b/_site/index.html
@@ -1,10 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-<meta charset="utf-8">
-<meta http-equiv="X-UA-Compatible" content="IE=edge">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<!-- Begin Jekyll SEO tag v2.7.1 -->
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!-- Begin Jekyll SEO tag v2.7.1 -->
 <title>SequenceServer | Use SequenceServer to pragmatically perform and interpret genomic comparisons using NCBI BLAST. SequenceServer accelerates your analyses so you can focus on the science.</title>
 <meta name="generator" content="Jekyll v3.9.1" />
 <meta property="og:title" content="SequenceServer" />
@@ -20,10 +21,11 @@
 {"@type":"WebSite","description":"Use SequenceServer to pragmatically perform and interpret genomic comparisons using NCBI BLAST. SequenceServer accelerates your analyses so you can focus on the science.","headline":"SequenceServer","name":"SequenceServer","url":"http://localhost:4000/","@context":"https://schema.org"}</script>
 <!-- End Jekyll SEO tag -->
 <meta name="author" content="Anurag Priyam">
-<meta name="author" content="Yannick Wurm">
-<meta name="keywords" content="local NCBI BLAST, custom BLAST, local BLAST server, BLAST web frontend, local BLAST, BLAST web interface, galaxy, viroblast">
-    <!-- Support HTML5 elements and media queries on IE8 and less. -->
-    <!--[if lt IE 9]>
+  <meta name="author" content="Yannick Wurm">
+  <meta name="keywords"
+    content="local NCBI BLAST, custom BLAST, local BLAST server, BLAST web frontend, local BLAST, BLAST web interface, galaxy, viroblast">
+  <!-- Support HTML5 elements and media queries on IE8 and less. -->
+  <!--[if lt IE 9]>
       <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.2/html5shiv.min.js"></script>
     <![endif]-->
 
@@ -48,6 +50,7 @@
     ga('send', 'pageview');
   </script>
 </head>
+
 <body>
   <nav class="navbar navbar-expand-xl navbar-light fixed-top">
     <div class="container">
@@ -95,8 +98,8 @@
             </a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="/#license">
-              License
+            <a class="nav-link" href="/paper">
+              Paper
             </a>
           </li>
           <li class="nav-item">
@@ -118,7 +121,7 @@
     </div>
   </nav>
   <div class="container">
-<div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 g-4 py-5 stats-banner" role="banner">
+    <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 g-4 py-5 stats-banner" role="banner">
     <div class="">
         <div>
             <p><i class="fa fa-quote-left" aria-hidden="true"></i> 130+ citations</p>
@@ -2129,10 +2132,6 @@
         Parts of SequenceServer are &copy; Universit&eacute; de Lausanne
         (2011).
       </p>
-      <p>
-        Archived site: <a href="http://www.sequenceserver.com/old/">
-          SequenceServer 0.8 (pre March 2015)</a>.
-      </p>
     </div>
   </footer>
 
@@ -2142,14 +2141,14 @@
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"
     integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM"
     crossorigin="anonymous"></script>
-    <script>
-      $(function(){
-        var navMain = $(".navbar-collapse");
-        navMain.on("click", "a:not([data-toggle])", null, function () {
-            navMain.collapse('hide');
-        });
+  <script>
+    $(function () {
+      var navMain = $(".navbar-collapse");
+      navMain.on("click", "a:not([data-toggle])", null, function () {
+        navMain.collapse('hide');
+      });
     });
-    </script>
+  </script>
 </body>
 
 </html>

--- a/_site/paper/blast-interface-design-and-implementation.html
+++ b/_site/paper/blast-interface-design-and-implementation.html
@@ -1,10 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-<meta charset="utf-8">
-<meta http-equiv="X-UA-Compatible" content="IE=edge">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<!-- Begin Jekyll SEO tag v2.7.1 -->
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!-- Begin Jekyll SEO tag v2.7.1 -->
 <title>Paper Supplementary Information. Sequenceserver: a modern graphical user interface for custom BLAST databases | SequenceServer</title>
 <meta name="generator" content="Jekyll v3.9.1" />
 <meta property="og:title" content="Paper Supplementary Information. Sequenceserver: a modern graphical user interface for custom BLAST databases" />
@@ -20,10 +21,11 @@
 {"@type":"WebPage","description":"Use SequenceServer to pragmatically perform and interpret genomic comparisons using NCBI BLAST. SequenceServer accelerates your analyses so you can focus on the science.","headline":"Paper Supplementary Information. Sequenceserver: a modern graphical user interface for custom BLAST databases","url":"http://localhost:4000/paper/blast-interface-design-and-implementation.html","@context":"https://schema.org"}</script>
 <!-- End Jekyll SEO tag -->
 <meta name="author" content="Anurag Priyam">
-<meta name="author" content="Yannick Wurm">
-<meta name="keywords" content="local NCBI BLAST, custom BLAST, local BLAST server, BLAST web frontend, local BLAST, BLAST web interface, galaxy, viroblast">
-    <!-- Support HTML5 elements and media queries on IE8 and less. -->
-    <!--[if lt IE 9]>
+  <meta name="author" content="Yannick Wurm">
+  <meta name="keywords"
+    content="local NCBI BLAST, custom BLAST, local BLAST server, BLAST web frontend, local BLAST, BLAST web interface, galaxy, viroblast">
+  <!-- Support HTML5 elements and media queries on IE8 and less. -->
+  <!--[if lt IE 9]>
       <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.2/html5shiv.min.js"></script>
     <![endif]-->
 
@@ -48,6 +50,7 @@
     ga('send', 'pageview');
   </script>
 </head>
+
 <body>
   <nav class="navbar navbar-expand-xl navbar-light fixed-top">
     <div class="container">
@@ -95,8 +98,8 @@
             </a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="/#license">
-              License
+            <a class="nav-link" href="/paper">
+              Paper
             </a>
           </li>
           <li class="nav-item">
@@ -118,7 +121,7 @@
     </div>
   </nav>
   <div class="container">
-<div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 g-4 py-5 stats-banner" role="banner">
+    <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 g-4 py-5 stats-banner" role="banner">
     <div class="">
         <div>
             <p><i class="fa fa-quote-left" aria-hidden="true"></i> 130+ citations</p>
@@ -549,10 +552,6 @@
         Parts of SequenceServer are &copy; Universit&eacute; de Lausanne
         (2011).
       </p>
-      <p>
-        Archived site: <a href="http://www.sequenceserver.com/old/">
-          SequenceServer 0.8 (pre March 2015)</a>.
-      </p>
     </div>
   </footer>
 
@@ -562,14 +561,14 @@
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"
     integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM"
     crossorigin="anonymous"></script>
-    <script>
-      $(function(){
-        var navMain = $(".navbar-collapse");
-        navMain.on("click", "a:not([data-toggle])", null, function () {
-            navMain.collapse('hide');
-        });
+  <script>
+    $(function () {
+      var navMain = $(".navbar-collapse");
+      navMain.on("click", "a:not([data-toggle])", null, function () {
+        navMain.collapse('hide');
+      });
     });
-    </script>
+  </script>
 </body>
 
 </html>

--- a/_site/paper/index.html
+++ b/_site/paper/index.html
@@ -1,10 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-<meta charset="utf-8">
-<meta http-equiv="X-UA-Compatible" content="IE=edge">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<!-- Begin Jekyll SEO tag v2.7.1 -->
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!-- Begin Jekyll SEO tag v2.7.1 -->
 <title>Sequenceserver: A Modern Graphical User Interface for Custom BLAST Databases | SequenceServer</title>
 <meta name="generator" content="Jekyll v3.9.1" />
 <meta property="og:title" content="Sequenceserver: A Modern Graphical User Interface for Custom BLAST Databases" />
@@ -20,10 +21,11 @@
 {"@type":"WebPage","description":"Use SequenceServer to pragmatically perform and interpret genomic comparisons using NCBI BLAST. SequenceServer accelerates your analyses so you can focus on the science.","headline":"Sequenceserver: A Modern Graphical User Interface for Custom BLAST Databases","url":"http://localhost:4000/paper/","@context":"https://schema.org"}</script>
 <!-- End Jekyll SEO tag -->
 <meta name="author" content="Anurag Priyam">
-<meta name="author" content="Yannick Wurm">
-<meta name="keywords" content="local NCBI BLAST, custom BLAST, local BLAST server, BLAST web frontend, local BLAST, BLAST web interface, galaxy, viroblast">
-    <!-- Support HTML5 elements and media queries on IE8 and less. -->
-    <!--[if lt IE 9]>
+  <meta name="author" content="Yannick Wurm">
+  <meta name="keywords"
+    content="local NCBI BLAST, custom BLAST, local BLAST server, BLAST web frontend, local BLAST, BLAST web interface, galaxy, viroblast">
+  <!-- Support HTML5 elements and media queries on IE8 and less. -->
+  <!--[if lt IE 9]>
       <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.2/html5shiv.min.js"></script>
     <![endif]-->
 
@@ -48,6 +50,7 @@
     ga('send', 'pageview');
   </script>
 </head>
+
 <body>
   <nav class="navbar navbar-expand-xl navbar-light fixed-top">
     <div class="container">
@@ -95,8 +98,8 @@
             </a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="/#license">
-              License
+            <a class="nav-link" href="/paper">
+              Paper
             </a>
           </li>
           <li class="nav-item">
@@ -118,7 +121,7 @@
     </div>
   </nav>
   <div class="container">
-<div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 g-4 py-5 stats-banner" role="banner">
+    <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 g-4 py-5 stats-banner" role="banner">
     <div class="">
         <div>
             <p><i class="fa fa-quote-left" aria-hidden="true"></i> 130+ citations</p>
@@ -206,10 +209,6 @@
         Parts of SequenceServer are &copy; Universit&eacute; de Lausanne
         (2011).
       </p>
-      <p>
-        Archived site: <a href="http://www.sequenceserver.com/old/">
-          SequenceServer 0.8 (pre March 2015)</a>.
-      </p>
     </div>
   </footer>
 
@@ -219,14 +218,14 @@
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"
     integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM"
     crossorigin="anonymous"></script>
-    <script>
-      $(function(){
-        var navMain = $(".navbar-collapse");
-        navMain.on("click", "a:not([data-toggle])", null, function () {
-            navMain.collapse('hide');
-        });
+  <script>
+    $(function () {
+      var navMain = $(".navbar-collapse");
+      navMain.on("click", "a:not([data-toggle])", null, function () {
+        navMain.collapse('hide');
+      });
     });
-    </script>
+  </script>
 </body>
 
 </html>

--- a/_site/progress-on-BLAST-interface.html
+++ b/_site/progress-on-BLAST-interface.html
@@ -1,10 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-<meta charset="utf-8">
-<meta http-equiv="X-UA-Compatible" content="IE=edge">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<!-- Begin Jekyll SEO tag v2.7.1 -->
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!-- Begin Jekyll SEO tag v2.7.1 -->
 <title>SequenceServer BLAST release notes | SequenceServer</title>
 <meta name="generator" content="Jekyll v3.9.1" />
 <meta property="og:title" content="SequenceServer BLAST release notes" />
@@ -22,10 +23,11 @@
 {"@type":"BlogPosting","description":"Use SequenceServer to pragmatically perform and interpret genomic comparisons using NCBI BLAST. SequenceServer accelerates your analyses so you can focus on the science.","headline":"SequenceServer BLAST release notes","dateModified":"2021-08-01T23:03:32-07:00","datePublished":"2021-08-01T23:03:32-07:00","mainEntityOfPage":{"@type":"WebPage","@id":"http://localhost:4000/progress-on-BLAST-interface.html"},"url":"http://localhost:4000/progress-on-BLAST-interface.html","@context":"https://schema.org"}</script>
 <!-- End Jekyll SEO tag -->
 <meta name="author" content="Anurag Priyam">
-<meta name="author" content="Yannick Wurm">
-<meta name="keywords" content="local NCBI BLAST, custom BLAST, local BLAST server, BLAST web frontend, local BLAST, BLAST web interface, galaxy, viroblast">
-    <!-- Support HTML5 elements and media queries on IE8 and less. -->
-    <!--[if lt IE 9]>
+  <meta name="author" content="Yannick Wurm">
+  <meta name="keywords"
+    content="local NCBI BLAST, custom BLAST, local BLAST server, BLAST web frontend, local BLAST, BLAST web interface, galaxy, viroblast">
+  <!-- Support HTML5 elements and media queries on IE8 and less. -->
+  <!--[if lt IE 9]>
       <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.2/html5shiv.min.js"></script>
     <![endif]-->
 
@@ -50,6 +52,7 @@
     ga('send', 'pageview');
   </script>
 </head>
+
 <body>
   <nav class="navbar navbar-expand-xl navbar-light fixed-top">
     <div class="container">
@@ -97,8 +100,8 @@
             </a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="/#license">
-              License
+            <a class="nav-link" href="/paper">
+              Paper
             </a>
           </li>
           <li class="nav-item">
@@ -120,7 +123,7 @@
     </div>
   </nav>
   <div class="container">
-<div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 g-4 py-5 stats-banner" role="banner">
+    <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 g-4 py-5 stats-banner" role="banner">
     <div class="">
         <div>
             <p><i class="fa fa-quote-left" aria-hidden="true"></i> 130+ citations</p>
@@ -400,10 +403,6 @@ Evolutionary genomics @ Queen Mary U London</p>
         Parts of SequenceServer are &copy; Universit&eacute; de Lausanne
         (2011).
       </p>
-      <p>
-        Archived site: <a href="http://www.sequenceserver.com/old/">
-          SequenceServer 0.8 (pre March 2015)</a>.
-      </p>
     </div>
   </footer>
 
@@ -413,14 +412,14 @@ Evolutionary genomics @ Queen Mary U London</p>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"
     integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM"
     crossorigin="anonymous"></script>
-    <script>
-      $(function(){
-        var navMain = $(".navbar-collapse");
-        navMain.on("click", "a:not([data-toggle])", null, function () {
-            navMain.collapse('hide');
-        });
+  <script>
+    $(function () {
+      var navMain = $(".navbar-collapse");
+      navMain.on("click", "a:not([data-toggle])", null, function () {
+        navMain.collapse('hide');
+      });
     });
-    </script>
+  </script>
 </body>
 
 </html>


### PR DESCRIPTION
- add link to `/paper` to main navigation
- remove redundant link to `#license`
- remove link to `/old` in footer